### PR TITLE
feat: integrate browser streaming service into playwright-mcp container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,11 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8931:8931"   # Playwright MCP server
+      - "8933:8933"   # Browser streaming WebSocket port
     restart: unless-stopped
     networks:
       - mastra-network
+
 
   # Main Mastra Application
   mastra-app:
@@ -18,9 +20,10 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "4111:4111"   # Mastra dev server  
+      - "4111:4112"   # Mastra dev server (external:internal)  
     environment:
       - PLAYWRIGHT_MCP_URL=http://playwright-mcp:8931/mcp
+      - BROWSER_STREAMING_URL=ws://browser-streaming:8933
       - NODE_ENV=production
     env_file:
       - .env

--- a/playwright-mcp/Dockerfile
+++ b/playwright-mcp/Dockerfile
@@ -47,20 +47,21 @@ RUN groupadd -r playwright && useradd -r -g playwright -d /app -s /bin/bash play
 RUN mkdir -p /app && chown -R playwright:playwright /app && \
     chown -R playwright:playwright /ms-playwright
 
+# Copy browser streaming server and startup script
+COPY browser-streaming-server.js /app/browser-streaming-server.js
+COPY start-services.sh /app/start-services.sh
+
+# Make startup script executable and set ownership
+RUN chmod +x /app/start-services.sh && chown playwright:playwright /app/start-services.sh /app/browser-streaming-server.js
+
 # Switch to non-root user
 USER playwright
 
 # Set working directory
 WORKDIR /app
 
-# Expose MCP server port
-EXPOSE 8931
+# Expose MCP server port and browser streaming port
+EXPOSE 8931 8933
 
-# Start Playwright MCP server
-CMD ["/usr/local/lib/node_modules/@playwright/mcp/cli.js", \
-     "--port", "8931", \
-     "--isolated", \
-     "--browser", "chromium", \
-     "--no-sandbox", \
-     "--user-agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36", \
-     "--viewport-size", "1920,1080"]
+# Start both services
+CMD ["/app/start-services.sh"]

--- a/playwright-mcp/browser-streaming-server.js
+++ b/playwright-mcp/browser-streaming-server.js
@@ -1,57 +1,35 @@
-import { WebSocketServer, WebSocket } from 'ws';
-import { EventEmitter } from 'events';
+#!/usr/bin/env node
 
-interface BrowserFrame {
-  type: 'frame';
-  data: string; // Base64 encoded image
-  timestamp: number;
-  sessionId: string;
-}
+// Standalone browser streaming server for client container
+const { WebSocketServer } = require('ws');
+const { EventEmitter } = require('events');
 
-interface BrowserStreamingMessage {
-  type: 'offer' | 'answer' | 'ice-candidate' | 'start-streaming' | 'stop-streaming' | 'control-mode' | 'user-input';
-  data?: any;
-  sessionId?: string;
-}
-
-export class BrowserStreamingService extends EventEmitter {
-  private wss: WebSocketServer;
-  private port: number;
-  private activeSessions = new Map<string, {
-    ws: WebSocket;
-    client: any; // CDP client
-    cdpEndpoint: string;
-    controlMode: 'agent' | 'user';
-  }>();
-  private cdpPort: number;
-
-  constructor(port: number, cdpPort: number = 9222) {
+class BrowserStreamingService extends EventEmitter {
+  constructor(port, cdpPort = 9222) {
     super();
     this.port = port;
     this.cdpPort = cdpPort; // Chrome DevTools Protocol port (fallback)
     this.wss = new WebSocketServer({ port });
+    this.activeSessions = new Map(); // Map<sessionId, {ws, client, cdpEndpoint, controlMode}>
   }
 
-
-
   async start() {
-    this.wss.on('connection', (ws: WebSocket, request: any) => {
+    this.wss.on('connection', (ws) => {
       console.log('Browser streaming client connected');
       
       ws.on('message', async (message) => {
         try {
-          const data: BrowserStreamingMessage = JSON.parse(message.toString());
+          const data = JSON.parse(message.toString());
           await this.handleMessage(ws, data);
         } catch (error) {
           console.error('Error handling browser streaming message:', error);
-          const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-          ws.send(JSON.stringify({ type: 'error', error: errorMessage }));
+          ws.send(JSON.stringify({ type: 'error', error: error.message }));
         }
       });
 
       ws.on('close', () => {
         console.log('Browser streaming client disconnected');
-        // Clean up any active sessions for this client
+        // Clean up sessions for this client
         for (const [sessionId, session] of this.activeSessions) {
           if (session.ws === ws) {
             this.stopBrowserCapture(sessionId);
@@ -60,7 +38,7 @@ export class BrowserStreamingService extends EventEmitter {
         }
       });
 
-      ws.on('error', (error: any) => {
+      ws.on('error', (error) => {
         console.error('Browser streaming WebSocket error:', error);
       });
     });
@@ -68,19 +46,7 @@ export class BrowserStreamingService extends EventEmitter {
     console.log(`Browser streaming service started on port ${this.port}`);
   }
 
-  async stop() {
-    // Stop all active sessions
-    for (const sessionId of this.activeSessions.keys()) {
-      await this.stopBrowserCapture(sessionId);
-    }
-    this.activeSessions.clear();
-
-    // Close WebSocket server
-    this.wss.close();
-    console.log('Browser streaming service stopped');
-  }
-
-  private async handleMessage(ws: WebSocket, message: BrowserStreamingMessage) {
+  async handleMessage(ws, message) {
     switch (message.type) {
       case 'start-streaming':
         await this.startBrowserCapture(ws, message.sessionId || 'default');
@@ -110,7 +76,7 @@ export class BrowserStreamingService extends EventEmitter {
     }
   }
 
-  private async startBrowserCapture(ws: WebSocket, sessionId: string) {
+  async startBrowserCapture(ws, sessionId) {
     try {
       // Connect to the Playwright MCP server's CDP endpoint with retry logic
       let cdpEndpoint = null;
@@ -155,9 +121,9 @@ export class BrowserStreamingService extends EventEmitter {
       });
 
       // Handle screencast frames with better error handling
-      Page.screencastFrame((params: any) => {
+      Page.screencastFrame((params) => {
         try {
-          const frame: BrowserFrame = {
+          const frame = {
             type: 'frame',
             data: params.data, // Base64 encoded JPEG
             timestamp: Date.now(),
@@ -165,9 +131,9 @@ export class BrowserStreamingService extends EventEmitter {
           };
 
           // Send frame to WebSocket client with connection check
-          if (ws.readyState === WebSocket.OPEN) {
+          if (ws.readyState === 1) { // WebSocket.OPEN
             ws.send(JSON.stringify(frame));
-          } else if (ws.readyState === WebSocket.CLOSED) {
+          } else if (ws.readyState === 3) { // WebSocket.CLOSED
             console.log(`WebSocket closed for session ${sessionId}, stopping capture`);
             this.stopBrowserCapture(sessionId);
             return;
@@ -208,7 +174,7 @@ export class BrowserStreamingService extends EventEmitter {
     }
   }
 
-  private async stopBrowserCapture(sessionId: string) {
+  async stopBrowserCapture(sessionId) {
     const session = this.activeSessions.get(sessionId);
     if (!session) {
       console.warn(`No active session found for: ${sessionId}`);
@@ -226,7 +192,7 @@ export class BrowserStreamingService extends EventEmitter {
       this.activeSessions.delete(sessionId);
       
       // Notify client that streaming stopped
-      if (session.ws.readyState === WebSocket.OPEN) {
+      if (session.ws.readyState === 1) { // WebSocket.OPEN
         session.ws.send(JSON.stringify({
           type: 'streaming-stopped',
           sessionId
@@ -240,7 +206,7 @@ export class BrowserStreamingService extends EventEmitter {
     }
   }
 
-  private async handleChangeControlMode(ws: WebSocket, sessionId: string, newMode: 'agent' | 'user') {
+  async handleChangeControlMode(ws, sessionId, newMode) {
     const session = this.activeSessions.get(sessionId);
     if (!session) {
       console.warn(`No active session found for control mode change: ${sessionId}`);
@@ -252,7 +218,7 @@ export class BrowserStreamingService extends EventEmitter {
       console.log(`Control mode for session ${sessionId} changed to: ${newMode}`);
 
       // Notify the client of the change
-      if (ws.readyState === WebSocket.OPEN) {
+      if (ws.readyState === 1) { // WebSocket.OPEN
         ws.send(JSON.stringify({
           type: 'control-mode-changed',
           sessionId,
@@ -264,7 +230,7 @@ export class BrowserStreamingService extends EventEmitter {
     }
   }
 
-  private async handleUserInput(ws: WebSocket, sessionId: string, inputData: any) {
+  async handleUserInput(ws, sessionId, inputData) {
     const session = this.activeSessions.get(sessionId);
     if (!session || session.controlMode !== 'user') {
       // Ignore user input if not in user control mode
@@ -333,13 +299,13 @@ export class BrowserStreamingService extends EventEmitter {
       }
     } catch (error) {
       console.error('Error handling user input:', error);
-      if (ws.readyState === WebSocket.OPEN) {
+      if (ws.readyState === 1) { // WebSocket.OPEN
         ws.send(JSON.stringify({ type: 'error', error: 'Failed to process user input' }));
       }
     }
   }
 
-  private async findChromePort(): Promise<number | null> {
+  async findChromePort() {
     try {
       // Use ps to find Playwright Chromium process with remote-debugging-port
       const { execSync } = require('child_process');
@@ -357,12 +323,12 @@ export class BrowserStreamingService extends EventEmitter {
       
       return null;
     } catch (error) {
-      console.log('Could not detect Playwright Chrome port:', (error as Error).message);
+      console.log('Could not detect Playwright Chrome port:', error.message);
       return null;
     }
   }
 
-  private async getCDPEndpoint(): Promise<string | null> {
+  async getCDPEndpoint() {
     try {
       // First try to find the actual Chrome port used by Playwright MCP
       const detectedPort = await this.findChromePort();
@@ -382,10 +348,10 @@ export class BrowserStreamingService extends EventEmitter {
       await new Promise(resolve => setTimeout(resolve, 1000));
       
       const targets = await CDP.List({ port: portToTry });
-      console.log('Available CDP targets:', targets.map((t: any) => ({ type: t.type, url: t.url, title: t.title })));
+      console.log('Available CDP targets:', targets.map(t => ({ type: t.type, url: t.url, title: t.title })));
       
       // Find the first page target
-      const pageTarget = targets.find((target: any) => target.type === 'page');
+      const pageTarget = targets.find(target => target.type === 'page');
       
       if (pageTarget) {
         console.log('Found page target:', pageTarget.webSocketDebuggerUrl);
@@ -393,25 +359,48 @@ export class BrowserStreamingService extends EventEmitter {
         return pageTarget.webSocketDebuggerUrl;
       }
       
-      console.warn('No page target found, available targets:', targets.map((t: any) => t.type));
+      console.warn('No page target found, available targets:', targets.map(t => t.type));
       return null;
       
     } catch (error) {
-      console.log('Error connecting to CDP (this is normal if browser not ready yet):', (error as Error).message);
+      console.log('Error connecting to CDP (this is normal if browser not ready yet):', error.message);
       return null;
     }
   }
 
-  private async handleWebRTCSignaling(ws: WebSocket, message: BrowserStreamingMessage) {
+  async handleWebRTCSignaling(ws, message) {
     // TODO: Implement WebRTC signaling for even lower latency
     // This would replace the CDP screencast approach with true WebRTC streaming
     console.log('WebRTC signaling not yet implemented:', message.type);
   }
+
+  async stop() {
+    // Stop all active sessions
+    for (const sessionId of this.activeSessions.keys()) {
+      await this.stopBrowserCapture(sessionId);
+    }
+    this.activeSessions.clear();
+
+    // Close WebSocket server
+    this.wss.close();
+    console.log('Browser streaming service stopped');
+  }
 }
 
-export function createBrowserStreamingService(port: number, cdpPort?: number): BrowserStreamingService {
+function createBrowserStreamingService(port, cdpPort) {
   const streamingPort = port || parseInt(process.env.BROWSER_STREAMING_PORT || '8933');
   const chromePort = cdpPort || parseInt(process.env.CHROME_CDP_PORT || '9222');
   
   return new BrowserStreamingService(streamingPort, chromePort);
 }
+
+// Start the service
+const port = process.env.BROWSER_STREAMING_PORT || 8933;
+const cdpPort = process.env.CHROME_CDP_PORT || 9222;
+const service = createBrowserStreamingService(port, cdpPort);
+
+service.start().catch(console.error);
+
+// Handle shutdown
+process.on('SIGTERM', () => service.stop().then(() => process.exit(0)));
+process.on('SIGINT', () => service.stop().then(() => process.exit(0)));

--- a/playwright-mcp/start-services.sh
+++ b/playwright-mcp/start-services.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Install browser streaming dependencies locally
+npm install ws chrome-remote-interface
+
+# Start browser streaming service in background
+node /app/browser-streaming-server.js &
+
+# Start Playwright MCP server in foreground
+exec /usr/local/lib/node_modules/@playwright/mcp/cli.js \
+     --port 8931 \
+     --isolated \
+     --browser chromium \
+     --no-sandbox \
+     --user-agent "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36" \
+     --viewport-size 1920,1080

--- a/src/mastra/mcp.ts
+++ b/src/mastra/mcp.ts
@@ -1,7 +1,6 @@
 import 'dotenv/config';
 import { MCPClient } from "@mastra/mcp";
 import { startArtifactWatcher } from './artifact-watcher';
-import { createBrowserStreamingService } from './browser-streaming';
 import path from 'path';
 
 // Create a unique session-based output directory
@@ -39,27 +38,3 @@ export const exaMCP = new MCPClient({
     },
   },
 });
-
-// Start browser streaming service (connects to Chrome CDP directly)
-const browserStreamingService = createBrowserStreamingService(
-  parseInt(process.env.BROWSER_STREAMING_PORT || '8933')
-);
-
-// Initialize browser streaming
-browserStreamingService.start().catch((error) => {
-  console.error('Failed to start browser streaming service:', error);
-});
-
-// Clean up on exit
-process.on('exit', () => {
-  browserStreamingService.stop();
-});
-
-process.on('SIGINT', () => {
-  browserStreamingService.stop().then(() => {
-    process.exit(0);
-  });
-});
-
-// Export browser streaming service for use in client
-export { browserStreamingService };

--- a/test-browser-streaming.html
+++ b/test-browser-streaming.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Browser Streaming Test - Port 8933</title>
+    <style>
+        body { font-family: Arial, sans-serif; padding: 20px; }
+        button { margin: 5px; padding: 10px 15px; }
+        #status { margin: 10px 0; font-weight: bold; }
+        #canvas { border: 2px solid #333; margin: 10px 0; display: block; }
+        .connected { color: green; }
+        .disconnected { color: red; }
+        .connecting { color: orange; }
+    </style>
+</head>
+<body>
+    <h1>Browser Streaming WebSocket Test</h1>
+    <p>Direct connection to <code>ws://localhost:8933</code></p>
+    
+    <div>
+        <button onclick="connect()">Connect</button>
+        <button onclick="startStreaming()">Start Streaming</button>
+        <button onclick="stopStreaming()">Stop Streaming</button>
+        <button onclick="disconnect()">Disconnect</button>
+    </div>
+    
+    <div id="status" class="disconnected">Not connected</div>
+    
+    <canvas id="canvas" width="960" height="540"></canvas>
+    
+    <div id="messages" style="margin-top: 20px; max-height: 200px; overflow-y: auto; border: 1px solid #ccc; padding: 10px; font-family: monospace; font-size: 12px;"></div>
+    
+    <script>
+        let ws = null;
+        let canvas = document.getElementById('canvas');
+        let ctx = canvas.getContext('2d');
+        let statusEl = document.getElementById('status');
+        let messagesEl = document.getElementById('messages');
+        
+        function log(message) {
+            const timestamp = new Date().toLocaleTimeString();
+            messagesEl.innerHTML += `[${timestamp}] ${message}<br>`;
+            messagesEl.scrollTop = messagesEl.scrollHeight;
+            console.log(message);
+        }
+        
+        function connect() {
+            if (ws) {
+                log('Already connected or connecting');
+                return;
+            }
+            
+            statusEl.textContent = 'Connecting...';
+            statusEl.className = 'connecting';
+            
+            ws = new WebSocket('ws://localhost:8933');
+            
+            ws.onopen = () => {
+                statusEl.textContent = 'Connected to WebSocket';
+                statusEl.className = 'connected';
+                log('WebSocket connection opened');
+            };
+            
+            ws.onmessage = (event) => {
+                try {
+                    const message = JSON.parse(event.data);
+                    log(`Received: ${message.type}`);
+                    
+                    if (message.type === 'frame') {
+                        // Draw the frame to canvas
+                        const img = new Image();
+                        img.onload = () => {
+                            ctx.clearRect(0, 0, canvas.width, canvas.height);
+                            ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+                        };
+                        img.src = `data:image/jpeg;base64,${message.data}`;
+                    } else if (message.type === 'streaming-started') {
+                        log(`Streaming started for session: ${message.sessionId}`);
+                    } else if (message.type === 'streaming-stopped') {
+                        log(`Streaming stopped for session: ${message.sessionId}`);
+                    } else if (message.type === 'error') {
+                        log(`ERROR: ${message.error}`);
+                    }
+                } catch (err) {
+                    log(`Error parsing message: ${err.message}`);
+                }
+            };
+            
+            ws.onclose = () => {
+                statusEl.textContent = 'Disconnected';
+                statusEl.className = 'disconnected';
+                log('WebSocket connection closed');
+                ws = null;
+            };
+            
+            ws.onerror = (error) => {
+                statusEl.textContent = 'Connection error';
+                statusEl.className = 'disconnected';
+                log(`WebSocket error: ${error}`);
+            };
+        }
+        
+        function startStreaming() {
+            if (!ws || ws.readyState !== WebSocket.OPEN) {
+                log('Not connected to WebSocket');
+                return;
+            }
+            
+            const message = {
+                type: 'start-streaming',
+                sessionId: 'test-session-' + Date.now()
+            };
+            
+            ws.send(JSON.stringify(message));
+            log(`Sent: ${message.type} for session ${message.sessionId}`);
+        }
+        
+        function stopStreaming() {
+            if (!ws || ws.readyState !== WebSocket.OPEN) {
+                log('Not connected to WebSocket');
+                return;
+            }
+            
+            const message = {
+                type: 'stop-streaming',
+                sessionId: 'test-session'
+            };
+            
+            ws.send(JSON.stringify(message));
+            log(`Sent: ${message.type}`);
+        }
+        
+        function disconnect() {
+            if (ws) {
+                ws.close();
+                ws = null;
+            }
+        }
+        
+        // Auto-connect on page load
+        window.onload = () => {
+            log('Page loaded. Click Connect to start.');
+        };
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Ticket

Adds browser streaming WebSocket service integration with Docker setup

## Changes

- Moved browser streaming functionality from separate container into playwright-mcp container
- Added start-services.sh script to run both MCP server (port 8931) and browser streaming (port 8933)
- Updated docker-compose.yml to expose browser streaming port and remove separate service
- Removed browser streaming imports from main mastra app since it's now handled separately
- Browser streaming can now access Chrome processes via ps aux in the same container

## Context for reviewers

The key issue was that browser streaming couldn't see Chrome processes across Docker containers. Moving it into the same container as Chrome allows the ps aux pattern matching to work properly and detect the actual debugging port that Chrome uses (like port 46773). This fixes the cross-container communication issue we were having with the separate browser-streaming service.

## Testing

Tested browser streaming WebSocket connection using test HTML page. Verified that:
- Both services start correctly in the same container
- Browser streaming can detect Chrome debugging ports via process scanning
- WebSocket connection works on port 8933
- Mastra app connects successfully to playwright-mcp service

## To replicate this:

1. Checkout this branch
2. Build and start the containers:
   ```bash
   docker compose down
   docker compose build
   docker compose up -d
   ```
3. Open `test-browser-streaming.html` in your browser (it's in the project root; you can do this with `open test-browser-streaming.html`)
4. Open http://localhost:4111 in another tab for the main Mastra chat app
5. In the chat app, send a message that triggers Playwright MCP (like "what's on the github landing page")
6. **While the browser automation is running**, go to your test-browser-streaming.html tab and:
   - Click "Connect" (should connect to ws://localhost:8933)
   - Click "Start Streaming" 
   - You should see live browser frames streaming in

## Screenshot

<img width="1166" height="988" alt="Screenshot 2025-09-24 at 8 19 37 PM" src="https://github.com/user-attachments/assets/08fcb08a-ef97-4536-9c0c-6cfe6b141a6f" />
