### PR TITLE
feat: add AI chatbot Docker containerization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,12 @@ GOOGLE_APPLICATION_CREDENTIALS=../../vertex-ai-credentials.json
 # Database Configuration
 DATABASE_URL="postgresql://..."
 
+# CORS Configuration (REQUIRED for Docker deployment)
+# Include all origins that need to access the Mastra server
+# For local development: localhost:3000 (ai-chatbot), localhost:3001, localhost:4111 (mastra-app)
+# For production: add your production domain
+CORS_ORIGINS="http://localhost:3000,http://localhost:3001,http://localhost:4111,http://0.0.0.0:4111"
+
 # Authentication Configuration
 MASTRA_JWT_SECRET=jwt-secret
 MASTRA_APP_PASSWORD=your-password

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,11 +46,11 @@ RUN chown -R mastra:mastra /app
 USER mastra
 
 # Expose Mastra port only
-EXPOSE 4111
+EXPOSE 4112
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD curl -f http://localhost:4111/health || curl -f http://localhost:4111 || exit 1
+    CMD curl -f http://localhost:4112/health || curl -f http://localhost:4112 || exit 1
 
 # Start Mastra server
 WORKDIR /app

--- a/Dockerfile.ai-chatbot
+++ b/Dockerfile.ai-chatbot
@@ -18,16 +18,8 @@ FROM base AS builder
 # Set working directory
 WORKDIR /app
 
-# Copy root package.json (needed for Mastra build)
-COPY package.json pnpm-lock.yaml ./
-COPY src/ ./src/
-COPY tsconfig.json ./
-
 # Copy client directory
 COPY client/ ./client/
-
-# Install root dependencies (for Mastra)
-RUN pnpm install --frozen-lockfile
 
 # Go to client directory and install client dependencies
 WORKDIR /app/client
@@ -41,12 +33,7 @@ ARG BROWSER_STREAMING_URL=ws://localhost:8933
 ENV PLAYWRIGHT_MCP_URL=${PLAYWRIGHT_MCP_URL}
 ENV BROWSER_STREAMING_URL=${BROWSER_STREAMING_URL}
 
-# Build Mastra from root directory (where it works) instead of from client
-WORKDIR /app
-RUN pnpm run build
-
-# Go back to client for Next.js build (skip mastra:build since we did it above)
-WORKDIR /app/client
+# Build Next.js client only
 RUN pnpm tsx lib/db/migrate && pnpm next build
 
 # Stage 2: Runtime stage
@@ -55,8 +42,6 @@ FROM base AS runtime
 # Copy built application
 WORKDIR /app
 COPY --from=builder /app/client ./client
-COPY --from=builder /app/src ./src
-COPY --from=builder /app/package.json /app/pnpm-lock.yaml ./
 
 # Create a non-root user for better security
 RUN groupadd -r nextjs && useradd -r -g nextjs -d /app -s /bin/bash nextjs

--- a/Dockerfile.ai-chatbot
+++ b/Dockerfile.ai-chatbot
@@ -28,10 +28,12 @@ RUN rm -rf node_modules && pnpm install --frozen-lockfile --ignore-scripts
 # Accept build args for MCP URLs
 ARG PLAYWRIGHT_MCP_URL=http://localhost:8931/mcp
 ARG BROWSER_STREAMING_URL=ws://localhost:8933
+ARG NEXT_PUBLIC_MASTRA_SERVER_URL=http://localhost:4111
 
 # Set environment variables for build time
 ENV PLAYWRIGHT_MCP_URL=${PLAYWRIGHT_MCP_URL}
 ENV BROWSER_STREAMING_URL=${BROWSER_STREAMING_URL}
+ENV NEXT_PUBLIC_MASTRA_SERVER_URL=${NEXT_PUBLIC_MASTRA_SERVER_URL}
 
 # Build Next.js client only
 RUN pnpm tsx lib/db/migrate && pnpm next build

--- a/Dockerfile.ai-chatbot
+++ b/Dockerfile.ai-chatbot
@@ -1,0 +1,81 @@
+# Dockerfile for AI Chatbot (Next.js client with embedded Mastra)
+FROM node:20-slim AS base
+
+# Install basic system dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    ca-certificates \
+    procps \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install pnpm globally
+RUN npm install -g pnpm
+
+# Stage 1: Build stage
+FROM base AS builder
+
+# Set working directory
+WORKDIR /app
+
+# Copy root package.json (needed for Mastra build)
+COPY package.json pnpm-lock.yaml ./
+COPY src/ ./src/
+COPY tsconfig.json ./
+
+# Copy client directory
+COPY client/ ./client/
+
+# Install root dependencies (for Mastra)
+RUN pnpm install --frozen-lockfile
+
+# Go to client directory and install client dependencies
+WORKDIR /app/client
+RUN rm -rf node_modules && pnpm install --frozen-lockfile --ignore-scripts
+
+# Accept build args for MCP URLs
+ARG PLAYWRIGHT_MCP_URL=http://localhost:8931/mcp
+ARG BROWSER_STREAMING_URL=ws://localhost:8933
+
+# Set environment variables for build time
+ENV PLAYWRIGHT_MCP_URL=${PLAYWRIGHT_MCP_URL}
+ENV BROWSER_STREAMING_URL=${BROWSER_STREAMING_URL}
+
+# Build Mastra from root directory (where it works) instead of from client
+WORKDIR /app
+RUN pnpm run build
+
+# Go back to client for Next.js build (skip mastra:build since we did it above)
+WORKDIR /app/client
+RUN pnpm tsx lib/db/migrate && pnpm next build
+
+# Stage 2: Runtime stage
+FROM base AS runtime
+
+# Copy built application
+WORKDIR /app
+COPY --from=builder /app/client ./client
+COPY --from=builder /app/src ./src
+COPY --from=builder /app/package.json /app/pnpm-lock.yaml ./
+
+# Create a non-root user for better security
+RUN groupadd -r nextjs && useradd -r -g nextjs -d /app -s /bin/bash nextjs
+
+# Change ownership of the app directory to the nextjs user
+RUN chown -R nextjs:nextjs /app
+
+# Switch to non-root user
+USER nextjs
+
+# Set working directory to client
+WORKDIR /app/client
+
+# Expose Next.js port
+EXPOSE 3000
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD curl -f http://localhost:3000/health || curl -f http://localhost:3000 || exit 1
+
+# Start Next.js server
+CMD ["pnpm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
       args:
         PLAYWRIGHT_MCP_URL: http://host.docker.internal:8931/mcp
         BROWSER_STREAMING_URL: ws://host.docker.internal:8933
+        NEXT_PUBLIC_MASTRA_SERVER_URL: http://localhost:4111
     ports:
       - "3000:3000"   # Next.js application
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # Playwright MCP Server
   playwright-mcp:
@@ -37,6 +35,45 @@ services:
       - playwright-mcp
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:4111/health", "||", "curl", "-f", "http://localhost:4111"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    restart: unless-stopped
+    networks:
+      - mastra-network
+
+  # AI Chatbot Next.js Application
+  ai-chatbot:
+    build:
+      context: .
+      dockerfile: Dockerfile.ai-chatbot
+      args:
+        PLAYWRIGHT_MCP_URL: http://host.docker.internal:8931/mcp
+        BROWSER_STREAMING_URL: ws://host.docker.internal:8933
+    ports:
+      - "3000:3000"   # Next.js application
+    environment:
+      - PLAYWRIGHT_MCP_URL=http://playwright-mcp:8931/mcp
+      - BROWSER_STREAMING_URL=ws://playwright-mcp:8933
+      - NODE_ENV=production
+      - NEXTAUTH_URL=http://localhost:3000
+    env_file:
+      - client/.env.local
+    volumes:
+      # Mount Google credentials if using local file
+      - ./vertex-ai-credentials.json:/app/vertex-ai-credentials.json:ro
+      
+      # Mount artifacts directory for local development
+      - ./artifacts:/app/artifacts
+      
+      # Mount client vertex ai credentials
+      - ./client/vertex-ai-credentials.json:/app/client/vertex-ai-credentials.json:ro
+    depends_on:
+      - playwright-mcp
+      - mastra-app
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/health", "||", "curl", "-f", "http://localhost:3000"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
-  # Playwright MCP Server
-  playwright-mcp:
+  # Browser Streaming Service (includes Playwright MCP)
+  browser-streaming:
     build:
       context: ./playwright-mcp
       dockerfile: Dockerfile
@@ -20,7 +20,7 @@ services:
     ports:
       - "4111:4112"   # Mastra dev server (external:internal)  
     environment:
-      - PLAYWRIGHT_MCP_URL=http://playwright-mcp:8931/mcp
+      - PLAYWRIGHT_MCP_URL=http://browser-streaming:8931/mcp
       - BROWSER_STREAMING_URL=ws://browser-streaming:8933
       - NODE_ENV=production
     env_file:
@@ -32,7 +32,7 @@ services:
       # Mount artifacts directory for local development
       - ./artifacts:/app/artifacts
     depends_on:
-      - playwright-mcp
+      - browser-streaming
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:4111/health", "||", "curl", "-f", "http://localhost:4111"]
       interval: 30s
@@ -54,10 +54,11 @@ services:
     ports:
       - "3000:3000"   # Next.js application
     environment:
-      - PLAYWRIGHT_MCP_URL=http://playwright-mcp:8931/mcp
-      - BROWSER_STREAMING_URL=ws://playwright-mcp:8933
+      - PLAYWRIGHT_MCP_URL=http://browser-streaming:8931/mcp
+      - BROWSER_STREAMING_URL=ws://browser-streaming:8933
       - NODE_ENV=production
       - NEXTAUTH_URL=http://localhost:3000
+      - NEXT_PUBLIC_MASTRA_SERVER_URL=http://localhost:4111
     env_file:
       - client/.env.local
     volumes:
@@ -70,7 +71,7 @@ services:
       # Mount client vertex ai credentials
       - ./client/vertex-ai-credentials.json:/app/client/vertex-ai-credentials.json:ro
     depends_on:
-      - playwright-mcp
+      - browser-streaming
       - mastra-app
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health", "||", "curl", "-f", "http://localhost:3000"]

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@ai-sdk/google-vertex": "^3.0.29",
     "@ai-sdk/openai": "^1.3.24",
     "@inquirer/prompts": "^7.8.6",
+    "@mastra/ai-sdk": "^0.0.4",
     "@mastra/core": "^0.16.3",
     "@mastra/evals": "^0.12.1",
     "@mastra/libsql": "^0.13.8",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.2.12",
-    "@ai-sdk/google": "^1.2.22",
-    "@ai-sdk/google-vertex": "^3.0.27",
+    "@ai-sdk/google": "^2.0.16",
+    "@ai-sdk/google-vertex": "^3.0.29",
     "@ai-sdk/openai": "^1.3.24",
     "@inquirer/prompts": "^7.8.6",
     "@mastra/core": "^0.16.3",

--- a/playwright-mcp/start-services.sh
+++ b/playwright-mcp/start-services.sh
@@ -9,6 +9,8 @@ node /app/browser-streaming-server.js &
 # Start Playwright MCP server in foreground
 exec /usr/local/lib/node_modules/@playwright/mcp/cli.js \
      --port 8931 \
+     --host 0.0.0.0 \
+     --allowed-hosts browser-streaming:8931,localhost:8931,0.0.0.0:8931 \
      --isolated \
      --browser chromium \
      --no-sandbox \

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,11 +12,11 @@ importers:
         specifier: ^1.2.12
         version: 1.2.12(zod@3.25.76)
       '@ai-sdk/google':
-        specifier: ^1.2.22
-        version: 1.2.22(zod@3.25.76)
+        specifier: ^2.0.16
+        version: 2.0.16(zod@3.25.76)
       '@ai-sdk/google-vertex':
-        specifier: ^3.0.27
-        version: 3.0.27(zod@3.25.76)
+        specifier: ^3.0.29
+        version: 3.0.29(zod@3.25.76)
       '@ai-sdk/openai':
         specifier: ^1.3.24
         version: 1.3.24(zod@3.25.76)
@@ -112,8 +112,8 @@ packages:
     peerDependencies:
       zod: ^3.0.0
 
-  '@ai-sdk/anthropic@2.0.17':
-    resolution: {integrity: sha512-fEmGD3H3cI4ahcrtU/ekA6xvUq9kk/IpOh2TI3wOSxqvKqpo+ztwiem5/x5R92Yenl9KRooYIefr0LNlFUR5Ow==}
+  '@ai-sdk/anthropic@2.0.18':
+    resolution: {integrity: sha512-WPlhSuIiTU0KRESMyhLwCTfrtgD0GsI6px4Q7hqidTvyfDhPDeXMB0q1WShzJPNRTrjpfWRDLuYdLEL/y/+mLQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4
@@ -130,20 +130,14 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4
 
-  '@ai-sdk/google-vertex@3.0.27':
-    resolution: {integrity: sha512-qR4+gLBNJPbnqaSBhvWktK0h3MfQryTLpKj9OWTYVhesNPqpkcchmbHmWBBXhI9kGN5niIknzHmCYdrtMqzF5w==}
+  '@ai-sdk/google-vertex@3.0.29':
+    resolution: {integrity: sha512-XJbZtMRj7EAJ1kmYvJdV1StgLLx7xYxrGg6buxeNcBWNTHgSNdQAoqdoG5uo5etfumkPR6mKV7D4ScREg+aPOg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4
 
-  '@ai-sdk/google@1.2.22':
-    resolution: {integrity: sha512-Ppxu3DIieF1G9pyQ5O1Z646GYR0gkC57YdBqXJ82qvCdhEhZHu0TWhmnOoeIWe2olSbuDeoOY+MfJrW8dzS3Hw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.0.0
-
-  '@ai-sdk/google@2.0.14':
-    resolution: {integrity: sha512-OCBBkEUq1RNLkbJuD+ejqGsWDD0M5nRyuFWDchwylxy0J4HSsAiGNhutNYVTdnqmNw+r9LyZlkyZ1P4YfAfLdg==}
+  '@ai-sdk/google@2.0.16':
+    resolution: {integrity: sha512-VN9QO1syIyKxYfAiS5QPZkw0caV6n/mmyvJui3T+lkhGPS2RXTv7nDrtRv8TroNzdPcPWoaZMgJRJD2W7oEZ+g==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4
@@ -3370,7 +3364,7 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/anthropic@2.0.17(zod@3.25.76)':
+  '@ai-sdk/anthropic@2.0.18(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@ai-sdk/provider-utils': 3.0.9(zod@3.25.76)
@@ -3388,10 +3382,10 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.9(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/google-vertex@3.0.27(zod@3.25.76)':
+  '@ai-sdk/google-vertex@3.0.29(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/anthropic': 2.0.17(zod@3.25.76)
-      '@ai-sdk/google': 2.0.14(zod@3.25.76)
+      '@ai-sdk/anthropic': 2.0.18(zod@3.25.76)
+      '@ai-sdk/google': 2.0.16(zod@3.25.76)
       '@ai-sdk/provider': 2.0.0
       '@ai-sdk/provider-utils': 3.0.9(zod@3.25.76)
       google-auth-library: 9.15.1
@@ -3400,13 +3394,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@ai-sdk/google@1.2.22(zod@3.25.76)':
-    dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
-      zod: 3.25.76
-
-  '@ai-sdk/google@2.0.14(zod@3.25.76)':
+  '@ai-sdk/google@2.0.16(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@ai-sdk/provider-utils': 3.0.9(zod@3.25.76)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@inquirer/prompts':
         specifier: ^7.8.6
         version: 7.8.6(@types/node@24.5.0)
+      '@mastra/ai-sdk':
+        specifier: ^0.0.4
+        version: 0.0.4(@mastra/core@0.16.3(effect@3.16.12)(openapi-types@12.1.3)(react@19.1.1)(zod@3.25.76))(zod@3.25.76)
       '@mastra/core':
         specifier: ^0.16.3
         version: 0.16.3(effect@3.16.12)(openapi-types@12.1.3)(react@19.1.1)(zod@3.25.76)
@@ -722,6 +725,12 @@ packages:
     resolution: {integrity: sha512-Fj0j8RnBpo43tVZUVoNK6BV/9AtDUM5S7DF3LB4qTYg1LMSZqi3yeCneUTLJD6XomQJlZzbI4mst89yspVSAnA==}
     cpu: [x64]
     os: [win32]
+
+  '@mastra/ai-sdk@0.0.4':
+    resolution: {integrity: sha512-bkqMg9lhDSQUljKXrI423kEyRWADO/JVW/6zJZsFlzVA9NW72p4dpPb6LyhZ16OvTut6o9Ng332utLfebQgRgA==}
+    peerDependencies:
+      '@mastra/core': '>=0.18.0-0 <0.19.0-0'
+      zod: ^3.25.0 || ^4.0.0
 
   '@mastra/core@0.16.3':
     resolution: {integrity: sha512-9dg/39iPk5rADtyscYeYXnYOTnAc6pbeHRBHNqG0TcAlUnlw69Rvnw8ew5H0r0DTnxsoV0gY58sk0WnHAOXTpg==}
@@ -3967,6 +3976,11 @@ snapshots:
 
   '@libsql/win32-x64-msvc@0.5.22':
     optional: true
+
+  '@mastra/ai-sdk@0.0.4(@mastra/core@0.16.3(effect@3.16.12)(openapi-types@12.1.3)(react@19.1.1)(zod@3.25.76))(zod@3.25.76)':
+    dependencies:
+      '@mastra/core': 0.16.3(effect@3.16.12)(openapi-types@12.1.3)(react@19.1.1)(zod@3.25.76)
+      zod: 3.25.76
 
   '@mastra/core@0.16.3(effect@3.16.12)(openapi-types@12.1.3)(react@19.1.1)(zod@3.25.76)':
     dependencies:

--- a/src/mastra/index.ts
+++ b/src/mastra/index.ts
@@ -3,6 +3,7 @@ import { Mastra } from '@mastra/core/mastra';
 import { PinoLogger } from '@mastra/loggers';
 import { webAutomationAgent } from './agents/web-automation-agent';
 import { serverMiddleware } from './middleware';
+import { chatRoute } from '@mastra/ai-sdk';
 
 export const mastra = new Mastra({
   agents: { 
@@ -38,7 +39,12 @@ export const mastra = new Mastra({
       swaggerUI: true,     // Enable Swagger UI in production
       openAPIDocs: true,   // Enable OpenAPI docs in production
     },
-
+    apiRoutes: [
+      chatRoute({
+        path: '/chat',
+        agent: 'webAutomationAgent',
+      }),
+    ],
     middleware: serverMiddleware,
   },
 });

--- a/src/mastra/index.ts
+++ b/src/mastra/index.ts
@@ -2,7 +2,6 @@ import { postgresStore } from './storage';
 import { Mastra } from '@mastra/core/mastra';
 import { PinoLogger } from '@mastra/loggers';
 import { webAutomationAgent } from './agents/web-automation-agent';
-import { serverMiddleware } from './middleware';
 import { chatRoute } from '@mastra/ai-sdk';
 
 export const mastra = new Mastra({
@@ -30,10 +29,9 @@ export const mastra = new Mastra({
     host: '0.0.0.0', // Allow external connections
     port: parseInt(process.env.MASTRA_PORT || '4112'),
     cors: {
-      origin: process.env.CORS_ORIGINS?.split(',') || ['http://localhost:4111', 'http://localhost:4112', '*'],
+      origin: process.env.CORS_ORIGINS?.split(',') || ['http://localhost:3000', 'http://localhost:3001', 'http://localhost:4111', 'http://localhost:4112'],
       allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
       allowHeaders: ['Content-Type', 'Authorization', 'x-mastra-dev-playground'],
-      credentials: true,
     },
     build: {
       swaggerUI: true,     // Enable Swagger UI in production
@@ -45,6 +43,5 @@ export const mastra = new Mastra({
         agent: 'webAutomationAgent',
       }),
     ],
-    middleware: serverMiddleware,
   },
 });


### PR DESCRIPTION
## Ticket

Adds Docker containerization support for the AI chatbot Next.js application.

## Changes

Added a new Dockerfile.ai-chatbot and updated docker-compose.yml to support running the AI chatbot frontend in a container alongside the existing Playwright MCP and Mastra services. Updated AI SDK packages to v2 for streamVNext compatibility and fixed build-time MCP connectivity.

Now you can run the full stack with `docker-compose up` and access the AI chatbot at http://localhost:3000 with working web automation capabilities.

## To replicate this

```bash
# Check if you have any services that are currently running
docker ps

# If any services are running you can remove them
docker compose down

# Build and start all services
docker compose build --no-cache

# Start all servces
docker compose up -d
```

Access points:
- AI Chatbot: http://localhost:3000
- Mastra API: http://localhost:4111  
- Playwright MCP: http://localhost:8931

Try going to http://localhost:3000 and asking something like, 'what is on the github landing page'

## Testing

Verified that all three services (playwright-mcp, mastra-app, ai-chatbot) start correctly and the web automation agent can access Playwright MCP tools. Tested both database connections (Neon and Cloud SQL) work from the containerized environment.

## Context for reviewers

The main challenge was getting the Mastra bundle import working correctly in the containerized Next.js build, since the bundler mangles export names. Also had to configure build-time MCP connectivity using host.docker.internal for the Docker build process.