### PR TITLE
feat: add api/chat/ route for ai-chatbot requests 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ EXPOSE 4112
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD curl -f http://localhost:4112/health || curl -f http://localhost:4112 || exit 1
+    CMD curl -f http://localhost:4112/health || exit 1
 
 # Start Mastra server
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     depends_on:
       - browser-streaming
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:4111/health", "||", "curl", "-f", "http://localhost:4111"]
+      test: ["CMD-SHELL", "curl -f http://localhost:4112/health || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Ticket

Adds new `/api/chat` endpoint for AI chatbot integration and improves Docker health checks

## Changes

- **Added `/api/chat` POST endpoint** with streaming support for AI chatbot requests
  - Validates incoming message arrays
  - Uses `webAutomationAgent` with `streamVNext()` for AI responses
  - Supports memory persistence via `threadId` and `resourceId`
  - Returns AI SDK UI message stream responses
  - Comprehensive error handling with proper JSON error responses

- **Added `/health` GET endpoint** for Docker health monitoring
  - Returns `{ status: 'ok', service: 'mastra-app' }`
  
- **Updated Docker health checks**
  - Simplified Dockerfile healthcheck to only use `/health` endpoint
  - Fixed docker-compose healthcheck syntax to use `CMD-SHELL`

## Context for reviewers

This PR implements the backend API route needed for the AI chatbot integration. The main change is converting from the simpler `chatRoute()` helper to a custom route handler that provides:

1. **Better error handling**: The original `chatRoute()` helper doesn't handle streaming errors well. This implementation catches errors at both the handler level and stream creation level, returning proper JSON responses.

2. **Health endpoint**: Needed for Docker to properly monitor service availability without false positives from the main application routes.

3. **Memory support**: Enables conversation persistence using Mastra's thread and resource ID system.

The implementation follows the AI SDK pattern for streaming responses (`toUIMessageStreamResponse()`) which is compatible with the Vercel AI SDK on the client side.