### PR TITLE
chore: bump client submodule for agent-browser Rust upgrade

### DIFF
--- a/Dockerfile.ai-chatbot
+++ b/Dockerfile.ai-chatbot
@@ -25,6 +25,10 @@ COPY client/ ./client/
 WORKDIR /app/client
 RUN rm -rf node_modules && pnpm install --frozen-lockfile --ignore-scripts
 
+# Download the agent-browser native Rust binary (requires network).
+# We use --ignore-scripts above, so postinstall did not run.
+RUN pnpm exec agent-browser install
+
 # Build args
 ARG NEXT_PUBLIC_POSTHOG_KEY
 ARG NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
@@ -53,6 +57,7 @@ COPY --from=builder /app/client ./client
 
 # Ensure agent-browser binary has execute permissions
 RUN chmod +x /app/client/node_modules/.pnpm/agent-browser@*/node_modules/agent-browser/bin/* 2>/dev/null || true
+RUN find /app/client/node_modules/agent-browser -type f -name 'agent-browser*' -exec chmod +x {} \; 2>/dev/null || true
 
 # Create a non-root user for better security
 RUN groupadd -r nextjs && useradd -r -g nextjs -d /app -s /bin/bash nextjs

--- a/Dockerfile.ai-chatbot
+++ b/Dockerfile.ai-chatbot
@@ -21,13 +21,12 @@ WORKDIR /app
 # Copy client directory
 COPY client/ ./client/
 
-# Go to client directory and install client dependencies
+# Go to client directory and install client dependencies.
+# Drop --ignore-scripts so agent-browser's postinstall runs and chmod+x's
+# its bundled Linux Rust binary. (Binaries ship in the npm tarball; no
+# download.) The postinstall is side-effect-safe for other packages.
 WORKDIR /app/client
-RUN rm -rf node_modules && pnpm install --frozen-lockfile --ignore-scripts
-
-# Download the agent-browser native Rust binary (requires network).
-# We use --ignore-scripts above, so postinstall did not run.
-RUN pnpm exec agent-browser install
+RUN rm -rf node_modules && pnpm install --frozen-lockfile
 
 # Build args
 ARG NEXT_PUBLIC_POSTHOG_KEY
@@ -55,9 +54,9 @@ FROM base AS runtime
 WORKDIR /app
 COPY --from=builder /app/client ./client
 
-# Ensure agent-browser binary has execute permissions
-RUN chmod +x /app/client/node_modules/.pnpm/agent-browser@*/node_modules/agent-browser/bin/* 2>/dev/null || true
-RUN find /app/client/node_modules/agent-browser -type f -name 'agent-browser*' -exec chmod +x {} \; 2>/dev/null || true
+# Ensure agent-browser platform binaries are executable (postinstall
+# handles this, but chmod is idempotent and survives --ignore-scripts).
+RUN find /app/client/node_modules -path '*agent-browser/bin/agent-browser-*' -exec chmod +x {} \; 2>/dev/null || true
 
 # Create a non-root user for better security
 RUN groupadd -r nextjs && useradd -r -g nextjs -d /app -s /bin/bash nextjs


### PR DESCRIPTION
## Summary

- Pin `client/` submodule to `chore/agent-browser-rust-upgrade` (PR navapbc/ai-chatbot#225), which migrates from the removed Node.js daemon APIs to the new Rust CLI.
- `Dockerfile.ai-chatbot`: add `pnpm exec agent-browser install` step to download the native Rust binary (our build uses `--ignore-scripts`, so the package's postinstall does not run automatically).
- Chmod the downloaded binary in the runtime stage.

## Dependency

- Submodule PR **navapbc/ai-chatbot#225 must merge first.** This PR will be rebased to point at the merged commit before merging.

## Test plan

- [ ] Docker build of `Dockerfile.ai-chatbot` succeeds (`agent-browser install` step downloads the Linux Rust binary)
- [ ] Preview deploy boots and `agent-browser --version` works inside the container
- [ ] Browser tool executes commands end-to-end against a Kernel browser in the preview env