### PR TITLE
chore: bump client submodule to PostHog session mapping (preview)

### DIFF
--- a/terraform/cloud_run.tf
+++ b/terraform/cloud_run.tf
@@ -15,7 +15,7 @@ resource "google_cloud_run_v2_service" "ai_chatbot" {
     # VPC Access - Connect to VPC network
     vpc_access {
       connector = local.vpc_connector.id
-      egress    = "ALL_TRAFFIC"  # Route all traffic through VPC/Cloud NAT for static IP
+      egress    = "ALL_TRAFFIC" # Route all traffic through VPC/Cloud NAT for static IP
     }
 
     containers {
@@ -97,7 +97,7 @@ resource "google_cloud_run_v2_service" "ai_chatbot" {
       # Apricot API Configuration
       # Prod uses /api/ endpoint with prod credentials, all others use /sandbox/ with sandbox credentials
       env {
-        name = "APRICOT_API_BASE_URL"
+        name  = "APRICOT_API_BASE_URL"
         value = "https://f5r-api.iws.sidekick.solutions/apricot"
       }
 
@@ -135,6 +135,24 @@ resource "google_cloud_run_v2_service" "ai_chatbot" {
       env {
         name  = "NEXT_PUBLIC_POSTHOG_HOST"
         value = "https://us.i.posthog.com"
+      }
+
+      # PostHog project id + app host, used server-side to build session-replay
+      # deep-links stored on the SessionMapping table. The app host (us.posthog.com)
+      # is distinct from the ingest host above (us.i.posthog.com).
+      env {
+        name = "POSTHOG_PROJECT_ID"
+        value_source {
+          secret_key_ref {
+            secret  = "posthog-project-id"
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name  = "POSTHOG_APP_HOST"
+        value = "https://us.posthog.com"
       }
 
       # Next.js Auth configuration

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -10,7 +10,7 @@ resource "google_storage_bucket" "dev" {
   count         = var.environment == "dev" ? 1 : 0
   name          = "nava-storage-dev"
   location      = local.region
-  force_destroy = false  # Prevent accidental deletion in dev
+  force_destroy = false # Prevent accidental deletion in dev
 
   # Versioning
   versioning {
@@ -18,9 +18,11 @@ resource "google_storage_bucket" "dev" {
   }
 
   # Lifecycle management
+  # 120 days so session-replay videos (replays/) are retained for the pilot
+  # rather than purged with shorter-lived artifacts.
   lifecycle_rule {
     condition {
-      age = 30  # days
+      age = 120 # days
     }
     action {
       type = "Delete"
@@ -49,7 +51,7 @@ resource "google_storage_bucket" "prod" {
   count         = var.environment == "prod" ? 1 : 0
   name          = "nava-storage-prod"
   location      = local.region
-  force_destroy = false  # Protect production bucket
+  force_destroy = false # Protect production bucket
 
   # Versioning
   versioning {
@@ -57,9 +59,10 @@ resource "google_storage_bucket" "prod" {
   }
 
   # Lifecycle management - longer retention for prod
+  # 120 days so session-replay videos (replays/) are retained for the pilot.
   lifecycle_rule {
     condition {
-      age = 90  # days - longer retention for production
+      age = 120 # days
     }
     action {
       type = "Delete"
@@ -81,10 +84,10 @@ resource "google_storage_bucket" "prod" {
 locals {
   storage_bucket_name = var.environment == "prod" ? (
     google_storage_bucket.prod[0].name
-  ) : var.environment == "dev" ? (
+    ) : var.environment == "dev" ? (
     google_storage_bucket.dev[0].name
-  ) : (
-    data.google_storage_bucket.dev[0].name  # Preview references existing dev bucket
+    ) : (
+    data.google_storage_bucket.dev[0].name # Preview references existing dev bucket
   )
 }
 


### PR DESCRIPTION
Bumps the `client` submodule to navapbc/ai-chatbot#262 (`7746b2a`) and adds the Terraform to support it.

### ai-chatbot #262 brings
- `SessionMapping` table: PostHog session id ↔ chat ↔ kernel session/replay
- Kernel browser **replay videos archived to GCS** on teardown (`replays/<chatId>/<kernelSessionId>.mp4`), URL stored on `kernelReplayUrl`
- PostHog **replay deep-link** stored on `posthogReplayUrl` (PostHog has no video export, so we keep the link)

### Terraform in this PR
- **cloud_run.tf**: inject `POSTHOG_PROJECT_ID` (new `posthog-project-id` Secret Manager secret, value `236687`) + `POSTHOG_APP_HOST` so the app can build PostHog replay links
- **storage.tf**: extend dev/prod bucket lifecycle **30/90 → 120 days** so kernel replay videos are retained for the pilot

### Notes
- The `posthog-project-id` secret is already created in Secret Manager (automatic replication), matching the existing `posthog-api-key` pattern.
- Migrations `0005` + `0006` apply on container boot.
- Opens a `preview-pr-383` deploy. The 'Verify client submodule is on develop' check stays red until #262 merges to `ai-chatbot:develop` — expected.

**Paired PR:** navapbc/ai-chatbot#262