### PR TITLE
chore: posthog replay mapping + GCS auth via runtime SA

### DIFF
--- a/terraform/cloud_run.tf
+++ b/terraform/cloud_run.tf
@@ -15,7 +15,7 @@ resource "google_cloud_run_v2_service" "ai_chatbot" {
     # VPC Access - Connect to VPC network
     vpc_access {
       connector = local.vpc_connector.id
-      egress    = "ALL_TRAFFIC"  # Route all traffic through VPC/Cloud NAT for static IP
+      egress    = "ALL_TRAFFIC" # Route all traffic through VPC/Cloud NAT for static IP
     }
 
     containers {
@@ -97,7 +97,7 @@ resource "google_cloud_run_v2_service" "ai_chatbot" {
       # Apricot API Configuration
       # Prod uses /api/ endpoint with prod credentials, all others use /sandbox/ with sandbox credentials
       env {
-        name = "APRICOT_API_BASE_URL"
+        name  = "APRICOT_API_BASE_URL"
         value = "https://f5r-api.iws.sidekick.solutions/apricot"
       }
 
@@ -135,6 +135,24 @@ resource "google_cloud_run_v2_service" "ai_chatbot" {
       env {
         name  = "NEXT_PUBLIC_POSTHOG_HOST"
         value = "https://us.i.posthog.com"
+      }
+
+      # PostHog project id + app host, used server-side to build session-replay
+      # deep-links stored on the SessionMapping table. The app host (us.posthog.com)
+      # is distinct from the ingest host above (us.i.posthog.com).
+      env {
+        name = "POSTHOG_PROJECT_ID"
+        value_source {
+          secret_key_ref {
+            secret  = "posthog-project-id"
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name  = "POSTHOG_APP_HOST"
+        value = "https://us.posthog.com"
       }
 
       # Next.js Auth configuration
@@ -210,11 +228,9 @@ resource "google_cloud_run_v2_service" "ai_chatbot" {
       }
 
       # Google Cloud configuration
-      env {
-        name  = "GOOGLE_APPLICATION_CREDENTIALS"
-        value = "/secrets/vertex/vertex-ai-credentials.json"
-      }
-
+      # No GOOGLE_APPLICATION_CREDENTIALS: all Google clients (GCS, Vertex,
+      # Cloud SQL, secrets) authenticate via Application Default Credentials as
+      # the per-env runtime SA, which holds storage.objectAdmin + aiplatform.user.
       env {
         name  = "GOOGLE_VERTEX_LOCATION"
         value = "global"
@@ -333,12 +349,6 @@ resource "google_cloud_run_v2_service" "ai_chatbot" {
         mount_path = "/cloudsql"
       }
 
-      # Volume mount for Vertex AI credentials file
-      volume_mounts {
-        name       = "vertex-credentials"
-        mount_path = "/secrets/vertex"
-      }
-
     }
 
     # Scaling configuration
@@ -359,18 +369,6 @@ resource "google_cloud_run_v2_service" "ai_chatbot" {
       name = "cloudsql"
       cloud_sql_instance {
         instances = [var.environment == "prod" ? "nava-labs:us-central1:nava-db-prod" : "nava-labs:us-central1:nava-db-dev"]
-      }
-    }
-
-    # Vertex AI credentials file (mounted from Secret Manager)
-    volumes {
-      name = "vertex-credentials"
-      secret {
-        secret = "vertex-ai-credentials"
-        items {
-          version = "latest"
-          path    = "vertex-ai-credentials.json"
-        }
       }
     }
   }

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -10,7 +10,7 @@ resource "google_storage_bucket" "dev" {
   count         = var.environment == "dev" ? 1 : 0
   name          = "nava-storage-dev"
   location      = local.region
-  force_destroy = false  # Prevent accidental deletion in dev
+  force_destroy = false # Prevent accidental deletion in dev
 
   # Versioning
   versioning {
@@ -18,9 +18,11 @@ resource "google_storage_bucket" "dev" {
   }
 
   # Lifecycle management
+  # 120 days so session-replay videos (replays/) are retained for the pilot
+  # rather than purged with shorter-lived artifacts.
   lifecycle_rule {
     condition {
-      age = 30  # days
+      age = 120 # days
     }
     action {
       type = "Delete"
@@ -49,7 +51,7 @@ resource "google_storage_bucket" "prod" {
   count         = var.environment == "prod" ? 1 : 0
   name          = "nava-storage-prod"
   location      = local.region
-  force_destroy = false  # Protect production bucket
+  force_destroy = false # Protect production bucket
 
   # Versioning
   versioning {
@@ -57,9 +59,10 @@ resource "google_storage_bucket" "prod" {
   }
 
   # Lifecycle management - longer retention for prod
+  # 120 days so session-replay videos (replays/) are retained for the pilot.
   lifecycle_rule {
     condition {
-      age = 90  # days - longer retention for production
+      age = 120 # days
     }
     action {
       type = "Delete"
@@ -81,10 +84,10 @@ resource "google_storage_bucket" "prod" {
 locals {
   storage_bucket_name = var.environment == "prod" ? (
     google_storage_bucket.prod[0].name
-  ) : var.environment == "dev" ? (
+    ) : var.environment == "dev" ? (
     google_storage_bucket.dev[0].name
-  ) : (
-    data.google_storage_bucket.dev[0].name  # Preview references existing dev bucket
+    ) : (
+    data.google_storage_bucket.dev[0].name # Preview references existing dev bucket
   )
 }
 


### PR DESCRIPTION
Fresh PR replacing #383 (whose preview-pr-383 terraform state is stale). Spins up a clean preview to verify the GCS fix end-to-end.

Bumps `client` → navapbc/ai-chatbot#262 (`2b3ab08`).

## The fix: GCS auth
GCS uploads have **never worked in any env** (both buckets empty) — the Storage client authed as the Vertex SA (`vertex-ai@`, no bucket access) because the container-wide `GOOGLE_APPLICATION_CREDENTIALS` keyfile hijacked ADC. Surfaced now by the kernel-replay archival (403 in logs).

**cloud_run.tf**: remove `GOOGLE_APPLICATION_CREDENTIALS` env + the `vertex-credentials` keyfile mount/volume. All Google clients (GCS, Vertex, Cloud SQL, secrets) now use ADC as the per-env runtime SA, which already holds **both** `storage.objectAdmin` and `aiplatform.user`. This mirrors the keyfile→ADC migration already done for the mastra VM (`terraform/DEPLOYMENT_GUIDE.md`).

## Also carried (from #383)
- **cloud_run.tf**: `POSTHOG_PROJECT_ID` + `POSTHOG_APP_HOST` for PostHog replay deep-links
- **storage.tf**: dev/prod bucket lifecycle 30/90 → 120 days so replay videos are retained

## Verify on the preview
1. **Vertex still works** (the risk): open a chat, get an LLM reply. If yes, ADC→runtime-SA for Vertex is confirmed (VM precedent says it will).
2. **GCS works**: run a browser task, let it tear down, then a `replays/<chatId>/<kernelSessionId>.mp4` object should appear in `nava-storage-dev` and `kernelReplayUrl` populate on SessionMapping.

**Paired:** navapbc/ai-chatbot#262. Supersedes #383 (close it).